### PR TITLE
Bundle issue fix for input-group

### DIFF
--- a/.changeset/brown-forks-count.md
+++ b/.changeset/brown-forks-count.md
@@ -1,0 +1,5 @@
+---
+"@locoworks/reusejs-react-input-group": patch
+---
+
+Bundle issue fix for input-group

--- a/components/input-group/package.json
+++ b/components/input-group/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "lint": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "build": "rollup -c --bundleConfigAsCjs",
+    "bundle": "rollup -c --bundleConfigAsCjs",
     "dev": "rollup -c -w --bundleConfigAsCjs"
   },
   "dependencies": {

--- a/components/input-group/src/HeadlessInputGroup.tsx
+++ b/components/input-group/src/HeadlessInputGroup.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { HeadlessInput } from "@locoworks/reusejs-react-input";
-import { HeadlessInputProps } from "@locoworks/reusejs-react-input/dist/types/src/HeadlessInput";
+import { HeadlessInputProps } from "@locoworks/reusejs-react-input/src/HeadlessInput";
 
 type ExtendedHeadlessInputInterface = Omit<HeadlessInputProps, "prefix">;
 export interface HeadlessInputGroupProps


### PR DESCRIPTION
Fix for bundling issue of reusejs-react input-group due to type inheritance.