### PR TITLE
Button prop fix

### DIFF
--- a/.changeset/large-pens-flash.md
+++ b/.changeset/large-pens-flash.md
@@ -1,0 +1,5 @@
+---
+"@locoworks/reusejs-react-button": major
+---
+
+Changed type declaration of busyText in headlessButton to 'React.ReactNode | string'

--- a/components/button/src/HeadlessButton.tsx
+++ b/components/button/src/HeadlessButton.tsx
@@ -2,7 +2,7 @@ import React, { FC, ButtonHTMLAttributes } from "react";
 
 export interface HeadlessButtonProps
 	extends ButtonHTMLAttributes<HTMLButtonElement> {
-	busyText?: string;
+	busyText?: React.ReactNode | string;
 	busy?: boolean;
 	buttonPrefix?: React.ReactNode;
 	buttonSuffix?: React.ReactNode;


### PR DESCRIPTION
Changed type for busyText inside HeadlessButton -
- `busyText?: React.ReactNode | string;`