### PR TITLE
Date picker Build Error Fix

### DIFF
--- a/.changeset/new-shirts-prove.md
+++ b/.changeset/new-shirts-prove.md
@@ -1,0 +1,6 @@
+---
+"@locoworks/reusejs-react-date-picker": major
+---
+
+- Resolved the error related to the missing declaration file for the '@locoworks/reusejs-react-date-picker' module.
+- Removed the inclusion of the hook from the tsconfig configuration.

--- a/components/date-picker/package.json
+++ b/components/date-picker/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
-  "types": "dist/types/index.d.ts",
+  "types": "dist/types/components/date-picker/index.d.ts",
   "prettier": "@betalectic-reusejs/shared-config-prettier-ts",
   "publishConfig": {
     "access": "public"

--- a/components/date-picker/tsconfig.json
+++ b/components/date-picker/tsconfig.json
@@ -10,6 +10,6 @@
     "strict": true,
     "target": "ESNext"
   },
-  "include": ["", "src", "../../toolkit/hooks/src/use-date-helpers.tsx"],
+  "include": ["", "src"],
   "exclude": ["dist/**", "src/main.tsx"]
 }


### PR DESCRIPTION
- Resolved the error related to the missing declaration file for the '@locoworks/reusejs-react-date-picker' module.
- Eliminated the inclusion of the unused hook from the tsconfig configuration.