### PR TITLE
Fixed issue with default selected options in useHeadlessSelectHook

### DIFF
--- a/.changeset/fifty-squids-burn.md
+++ b/.changeset/fifty-squids-burn.md
@@ -1,0 +1,5 @@
+---
+"@locoworks/reusejs-toolkit-react-hooks": minor
+---
+
+Fixed issue with default selected options in useHeadlessSelectHook

--- a/toolkit/hooks/src/use-headless-select-hook.ts
+++ b/toolkit/hooks/src/use-headless-select-hook.ts
@@ -130,6 +130,12 @@ export const useHeadlessSelectHook = ({
 		[selectedValues],
 	);
 
+	useEffect(() => {
+		if (defaultSelected.length > 0) {
+			setSelectedValues(defaultSelected);
+		}
+	}, []);
+
 	return {
 		open,
 		setOpen,


### PR DESCRIPTION
added useEffect To set the default values passed to the hook.